### PR TITLE
替换弃用的方法 & JSON 代码块未匹配直接尝试对其解码

### DIFF
--- a/response_format/__init__.py
+++ b/response_format/__init__.py
@@ -2,10 +2,10 @@ from response_format.parser import (
     parse_content_to_json,
     parse_model_to_json
 )
-from response_format.prompt import json_output_prompt_getter
+from response_format.prompt import format_prompt_getter
 
 __all__ = (
     "parse_content_to_json",
     "parse_model_to_json",
-    "json_output_prompt_getter"
+    "format_prompt_getter"
 )

--- a/response_format/parser.py
+++ b/response_format/parser.py
@@ -25,6 +25,14 @@ def parse_content_to_json(content: str) -> tuple[str, dict]:
     action_match = PATTERN.search(content)
     if action_match is not None:
         json_text, json_object = _try_parse_json_object(action_match.group(1).strip())
+    else:
+        # 如果没有匹配到特定的字符开头，尝试直接对齐进行解码
+        try:
+            json_object = json.loads(content)
+            json_text = content
+        except json.JSONDecodeError:
+            return json_text, json_object
+
     return json_text, json_object
 
 


### PR DESCRIPTION
# 替换弃用的方法

项目中的 `__init__.py` 有代码段：

```python
from response_format.parser import (
    parse_content_to_json,
    parse_model_to_json
)
from response_format.prompt import json_output_prompt_getter

__all__ = (
    "parse_content_to_json",
    "parse_model_to_json",
    "json_output_prompt_getter"
)
```

但是在 `prompt.py` 中没有 `json_output_prompt_getter` 方法，应该使用 `format_prompt_getter` 代替。

# JSON 代码块未匹配直接尝试对其解码

实测部分模型，如通义千问，在使用生成的系统提示词之后，直接返回了标准的 JSON 格式数据，所以在未匹配到 JSON 代码块的时候，应该先尝试对其直接进行解码。

![image](https://github.com/user-attachments/assets/b8857037-87f6-4c18-bc9d-d3d535c73746)

![image](https://github.com/user-attachments/assets/d79f86cf-1ed3-4747-87c4-8f6c28fe3e1d)


